### PR TITLE
Add XP reset time display and additional process termination

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -297,7 +297,8 @@
       "description": "Check your XP progress from Battle Royale, Creative and Save the World."
     },
     "check": "Check Earned XP",
-    "loading": "Loading"
+    "loading": "Loading",
+    "resetsAt": "Resets at {time}"
   },
   "itemShop": {
     "page": {

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -296,7 +296,8 @@
       "description": "Battle Royale, Kreatif ve Dünyayı Kurtar'da kazandığınız TP'yi görüntüleyin."
     },
     "check": "Kazanılan TP'yi Al",
-    "loading": "Kazanılan TP Alınıyor"
+    "loading": "Kazanılan TP Alınıyor",
+    "resetsAt": "Sıfırlanma tarihi: {time}"
   },
   "itemShop": {
     "page": {

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -89,6 +89,24 @@
             "FortniteClient-Win64-Shipping.exe",
             "/F"
           ]
+        },
+        {
+          "name": "kill-eac-eos",
+          "cmd": "taskkill",
+          "args": [
+            "/F",
+            "/IM",
+            "EasyAntiCheat_EOS.exe"
+          ]
+        },
+        {
+          "name": "kill-game-eac",
+          "cmd": "taskkill",
+          "args": [
+            "/F",
+            "/IM",
+            "FortniteClient-Win64-Shipping_EAC.exe"
+          ]
         }
       ]
     },

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -91,7 +91,7 @@
           ]
         },
         {
-          "name": "kill-eac-eos",
+          "name": "kill-eos-eac",
           "cmd": "taskkill",
           "args": [
             "/F",

--- a/src/lib/components/header/LaunchGame.svelte
+++ b/src/lib/components/header/LaunchGame.svelte
@@ -88,11 +88,10 @@
 
     try {
       const result = await Command.create('kill-fortnite').execute();
-      const result2 = await Command.create("kill-eac-eos").execute();
-      const result3 = await Command.create('kill-game-eac').execute();
+      Command.create('kill-eos-eac').execute().catch(() => null);
+      Command.create('kill-game-eac').execute().catch(() => null);
+
       if (result.stderr) throw new Error(result.stderr);
-      // if (result2.stderr) throw new Error(result2.stderr); // isnt always running, so commented out so launcher doesnt say it failed.
-      // if (result3.stderr) throw new Error(result3.stderr); // isnt always running, so commented out so launcher doesnt say it failed.
 
       isLaunching = false;
       isGameRunning = false;

--- a/src/lib/components/header/LaunchGame.svelte
+++ b/src/lib/components/header/LaunchGame.svelte
@@ -88,7 +88,11 @@
 
     try {
       const result = await Command.create('kill-fortnite').execute();
+      const result2 = await Command.create("kill-eac-eos").execute();
+      const result3 = await Command.create('kill-game-eac').execute();
       if (result.stderr) throw new Error(result.stderr);
+      // if (result2.stderr) throw new Error(result2.stderr); // isnt always running, so commented out so launcher doesnt say it failed.
+      // if (result3.stderr) throw new Error(result3.stderr); // isnt always running, so commented out so launcher doesnt say it failed.
 
       isLaunching = false;
       isGameRunning = false;

--- a/src/routes/br-stw/earned-xp/+page.svelte
+++ b/src/routes/br-stw/earned-xp/+page.svelte
@@ -5,10 +5,30 @@
     battleRoyale: number;
     creative: number;
     saveTheWorld: number;
+    resetDate: Date;
+    stwResetDate: Date;
   }>;
 
   let isFetching = $state(false);
   let xpStatuses = $state<XPStatus[]>([]);
+
+  function getNextSunday(): Date {
+    const now = new Date();
+    const daysUntilSunday = 7 - now.getDay();
+    const nextSunday = new Date(now);
+    nextSunday.setDate(now.getDate() + (daysUntilSunday === 7 ? 0 : daysUntilSunday));
+    nextSunday.setHours(0, 0, 0, 0);
+    return nextSunday;
+  }
+
+  function getNextThursday(): Date {
+    const now = new Date();
+    const daysUntilThursday = 4 - now.getDay();
+    const nextThursday = new Date(now);
+    nextThursday.setDate(now.getDate() + (daysUntilThursday === 7 ? 0 : daysUntilThursday));
+    nextThursday.setHours(0, 0, 0, 0);
+    return nextThursday;
+  }
 </script>
 
 <script lang="ts">
@@ -27,10 +47,13 @@
     doingBulkOperations.set(true);
     xpStatuses = [];
 
+    const nextSunday = getNextSunday();
+    const nextThursday = getNextThursday();
+    
     const accounts = selectedAccounts.map((accountId) => $accountsStore.allAccounts.find((account) => account.accountId === accountId)).filter(x => !!x);
     await Promise.allSettled(accounts.map(async (account) => {
       const status = xpStatuses.find((status) => status.accountId === account.accountId) ||
-        { accountId: account.accountId, displayName: account.displayName, data: {} as XPStatus['data'] } satisfies XPStatus;
+        { accountId: account.accountId, displayName: account.displayName, data: { resetDate: nextSunday, stwResetDate: nextThursday } as XPStatus['data'] } satisfies XPStatus;
 
       if (!xpStatuses.includes(status)) xpStatuses = [...xpStatuses, status];
 
@@ -43,6 +66,7 @@
         const attributes = athenaProfile.profileChanges[0].profile.stats.attributes;
         status.data.creative = attributes.creative_dynamic_xp?.currentWeekXp || 0;
         status.data.battleRoyale = attributes.playtime_xp?.currentWeekXp || 0;
+        status.data.resetDate = nextSunday;
       }
 
       if (campaignProfile) {
@@ -50,6 +74,7 @@
         const xpItem = items.find((item) => item.templateId === 'Token:stw_accolade_tracker');
         if (xpItem) {
           status.data.saveTheWorld = xpItem.attributes?.weekly_xp || 0;
+          status.data.stwResetDate = nextThursday;
         }
       }
     }));
@@ -128,6 +153,17 @@
                   class="h-full bg-epic"
                 ></div>
               </div>
+              {#if gamemode.name === $t('common.gameModes.saveTheWorld') && status.data.stwResetDate}
+                <div class="text-sm text-muted-foreground mt-1">
+                  Resets At: {status.data.stwResetDate.toLocaleDateString()}, 7:00 PM EST
+                </div>
+              {/if}
+
+              {#if gamemode.name !== $t('common.gameModes.saveTheWorld') && status.data.resetDate}
+                <div class="text-sm text-muted-foreground mt-1">
+                  Resets At: {status.data.resetDate.toLocaleDateString()}, 7:00 PM EST
+                </div>
+              {/if}
             </div>
           {/each}
         </div>

--- a/src/routes/br-stw/earned-xp/+page.svelte
+++ b/src/routes/br-stw/earned-xp/+page.svelte
@@ -11,29 +11,11 @@
 
   let isFetching = $state(false);
   let xpStatuses = $state<XPStatus[]>([]);
-
-  function getNextSunday(): Date {
-    const now = new Date();
-    const daysUntilSunday = 7 - now.getDay();
-    const nextSunday = new Date(now);
-    nextSunday.setDate(now.getDate() + (daysUntilSunday === 7 ? 0 : daysUntilSunday));
-    nextSunday.setHours(0, 0, 0, 0);
-    return nextSunday;
-  }
-
-  function getNextThursday(): Date {
-    const now = new Date();
-    const daysUntilThursday = 4 - now.getDay();
-    const nextThursday = new Date(now);
-    nextThursday.setDate(now.getDate() + (daysUntilThursday === 7 ? 0 : daysUntilThursday));
-    nextThursday.setHours(0, 0, 0, 0);
-    return nextThursday;
-  }
 </script>
 
 <script lang="ts">
   import CenteredPageContent from '$components/CenteredPageContent.svelte';
-  import { accountsStore, doingBulkOperations } from '$lib/stores';
+  import { accountsStore, doingBulkOperations, language } from '$lib/stores';
   import Button from '$components/ui/Button.svelte';
   import AccountCombobox from '$components/auth/account/AccountCombobox.svelte';
   import { getResolvedResults, t } from '$lib/utils/util';
@@ -47,9 +29,9 @@
     doingBulkOperations.set(true);
     xpStatuses = [];
 
-    const nextSunday = getNextSunday();
-    const nextThursday = getNextThursday();
-    
+    const nextSunday = getNextDayOfWeek(0);
+    const nextThursday = getNextDayOfWeek(4);
+
     const accounts = selectedAccounts.map((accountId) => $accountsStore.allAccounts.find((account) => account.accountId === accountId)).filter(x => !!x);
     await Promise.allSettled(accounts.map(async (account) => {
       const status = xpStatuses.find((status) => status.accountId === account.accountId) ||
@@ -83,6 +65,18 @@
     selectedAccounts = [];
     isFetching = false;
   }
+
+  function getNextDayOfWeek(dayIndex: number) {
+    const now = new Date();
+    const currentDay = now.getDay();
+    const daysUntilTarget = (7 + dayIndex - currentDay) % 7;
+
+    const nextDay = new Date();
+    nextDay.setUTCDate(now.getDate() + (daysUntilTarget === 0 ? 7 : daysUntilTarget));
+    nextDay.setUTCHours(0, 0, 0, 0);
+
+    return nextDay;
+  }
 </script>
 
 <CenteredPageContent
@@ -112,16 +106,19 @@
       {#snippet content(status)}
         {@const gamemodes = [
           {
+            id: 'battleRoyale',
             name: $t('common.gameModes.battleRoyale'),
             value: status.data.battleRoyale || 0,
             limit: 4_000_000
           },
           {
+            id: 'creative',
             name: $t('common.gameModes.creative'),
             value: status.data.creative || 0,
             limit: 4_000_000
           },
           {
+            id: 'saveTheWorld',
             name: $t('common.gameModes.saveTheWorld'),
             value: status.data.saveTheWorld || 0,
             limit: 4_000_000
@@ -129,7 +126,9 @@
         ]}
 
         <div class="bg-muted/30 p-3 space-y-6">
-          {#each gamemodes as gamemode (gamemode.name)}
+          {#each gamemodes as gamemode (gamemode.id)}
+            {@const resetDate = gamemode.id === 'saveTheWorld' ? status.data.stwResetDate : status.data.resetDate}
+
             <div class="space-y-1">
               <div class="flex items-center justify-between">
                 <div class="flex items-center gap-1.5">
@@ -149,21 +148,14 @@
 
               <div class="h-2 w-full bg-muted rounded-full overflow-hidden">
                 <div
-                  style="width: {Math.min(100,(gamemode.value / gamemode.limit) * 100)}%"
+                  style="width: {Math.min(100, (gamemode.value / gamemode.limit) * 100)}%"
                   class="h-full bg-epic"
                 ></div>
               </div>
-              {#if gamemode.name === $t('common.gameModes.saveTheWorld') && status.data.stwResetDate}
-                <div class="text-sm text-muted-foreground mt-1">
-                  Resets At: {status.data.stwResetDate.toLocaleDateString()}, 7:00 PM EST
-                </div>
-              {/if}
 
-              {#if gamemode.name !== $t('common.gameModes.saveTheWorld') && status.data.resetDate}
-                <div class="text-sm text-muted-foreground mt-1">
-                  Resets At: {status.data.resetDate.toLocaleDateString()}, 7:00 PM EST
-                </div>
-              {/if}
+              <div class="text-sm text-muted-foreground mt-1">
+                {$t('earnedXP.resetsAt', { time: resetDate.toLocaleString($language) })}
+              </div>
             </div>
           {/each}
         </div>


### PR DESCRIPTION
# Updates:
- Earned Xp page now shows xp reset time.
- Updated Stop button to also close EasyAntiCheat.

## Todo:
- Add translation for xp reset time (i was lazy and didnt wanna do)